### PR TITLE
Use the window location properties instead of 'http://localhost:80'

### DIFF
--- a/src/client/factory.js
+++ b/src/client/factory.js
@@ -93,9 +93,9 @@ function createProxies(config, map, parentPath) {
  */
 function getConfigFromBrowser() {
   var defaultLocation = {
-    port: '80',
-    hostname: 'localhost',
-    protocol: 'http:'
+    port: window.location.port,
+    hostname: window.location.hostname,
+    protocol: window.location.protocol
   };
 
   var wLocation = (global.location && global.location.port)


### PR DESCRIPTION
When using a custom local domain, isomorphine will still use `http://localhost/isomorphine/...